### PR TITLE
Moved GEOM based functions to AdvancedConstruct.py

### DIFF
--- a/src/addons/Utils/AdvancedConstruct.py
+++ b/src/addons/Utils/AdvancedConstruct.py
@@ -1,0 +1,47 @@
+# -*- coding: iso-8859-1 -*-
+#!/usr/bin/env python
+
+##Copyright 2011 Jelle Feringa (jelleferinga@gmail.com)
+##
+##This file is part of pythonOCC.
+##
+##pythonOCC is free software: you can redistribute it and/or modify
+##it under the terms of the GNU Lesser General Public License as published by
+##the Free Software Foundation, either version 3 of the License, or
+##(at your option) any later version.
+##
+##pythonOCC is distributed in the hope that it will be useful,
+##but WITHOUT ANY WARRANTY; without even the implied warranty of
+##MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+##GNU Lesser General Public License for more details.
+##
+##You should have received a copy of the GNU Lesser General Public License
+##along with pythonOCC.  If not, see <http://www.gnu.org/licenses/>.
+
+'''
+
+This modules makes the construction of geometry a little easier
+with the help of the GEOM library.
+
+'''
+
+from __future__ import with_statement
+import sys
+
+try:
+    from OCC.GEOMAlgo import GEOMAlgo_Splitter
+except ImportError:
+    print "GEOM wrapper is necesary to access advanced constructs."
+    sys.exit(0)
+
+def splitter(shape, profile):
+    '''split a *shape* using a *profile*
+    :returns the splitted shape
+    '''
+    splitter = GEOMAlgo_Splitter()
+    splitter.AddShape(shape)
+    splitter.AddTool(profile)
+    splitter.Perform()
+    splitter_shape = splitter.Shape()
+    return splitter_shape
+

--- a/src/addons/Utils/Construct.py
+++ b/src/addons/Utils/Construct.py
@@ -46,9 +46,6 @@ from OCC.GeomFill import *
 from OCC.TopTools import *
 from OCC.Geom import *
 
-# GEOM
-from OCC.GEOMAlgo import GEOMAlgo_Splitter
-
 # high level
 from OCC.Utils.Common import *
 from OCC.Utils.Context import assert_isdone
@@ -553,17 +550,6 @@ def boolean_fuse_old(shapeToCutFrom, joiningShape):
     shape = join.Shape()
     join.Delete()
     return shape
-
-def splitter(shape, profile):
-    '''split a *shape* using a *profile*
-    :returns the splitted shape
-    '''
-    splitter = GEOMAlgo_Splitter()
-    splitter.AddShape(shape)
-    splitter.AddTool(profile)
-    splitter.Perform()
-    splitter_shape = splitter.Shape()
-    return splitter_shape
 
 def trim_wire(wire, shapeLimit1, shapeLimit2, periodic=False):
     '''return the trimmed wire that lies between `shapeLimit1` and `shapeLimit2`


### PR DESCRIPTION
AdvancedConcsruct requires that the GEOM wrapper is built, but Construct.py does not depend on GEOM anymore.
