### PR TITLE
Bug fix: make export example work on localized Linux systems

### DIFF
--- a/src/examples/Level1/OCAF/step_export.py
+++ b/src/examples/Level1/OCAF/step_export.py
@@ -1,3 +1,4 @@
+import locale
 from OCC.XCAFApp import *
 from OCC.STEPCAFControl import *
 from OCC.TDocStd import *
@@ -82,16 +83,23 @@ def step_export_layers_and_colors(event=None):
     aisPres = TPrsStd.TPrsStd_AISPresentation().Set(top_label, XCAFPrs.XCAFPrs_Driver().GetID())
     aisPres.GetObject().Display(True)
     display.FitAll()
-
+    
     # write the stuff to STEP, with layers & colors
     WS = XSControl_WorkSession()
     writer = STEPCAFControl_Writer( WS.GetHandle(), False )
     writer.Transfer(h_doc, STEPControl_AsIs)
+    # workaround for an OCC bug: temporarily changing the locale in order to 
+    # avoid issues when exporting, see:
+    # http://tracker.dev.opencascade.org/view.php?id=22898
+    loc = locale.getlocale()
+    locale.setlocale(locale.LC_ALL, 'C')
     pth = '.'
     print 'writing STEP file'
     status = writer.Write(os.path.join(pth, 'step_layers_colors.step'))
     print 'status:', status
-    
+    # restoring the old locale
+    locale.setlocale(locale.LC_ALL, loc)
+
 def exit(event=None):
     sys.exit()
 
@@ -100,6 +108,3 @@ if __name__ == '__main__':
     add_function_to_menu('step ocaf export', step_export_layers_and_colors)
     add_function_to_menu('step ocaf export', exit)
     start_display()
-
-    
-


### PR DESCRIPTION
Adding a workaround for an OCC bug which causes the examle at 'src/examples/Level1/OCAF/step_export.py' to fail in a localized Linux environment. Fixes this issue: https://github.com/tpaviot/pythonocc/issues/67

(check twice before accepting - this is my first contribution to an open source project)
