### PR TITLE
Fix/smesh

### DIFF
--- a/src/contrib/smesh-5.1.2.2/src/StdMeshers/StdMeshers_RadialPrism_3D.cpp
+++ b/src/contrib/smesh-5.1.2.2/src/StdMeshers/StdMeshers_RadialPrism_3D.cpp
@@ -44,7 +44,7 @@
 
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
-#include <BRepTools.hxx>
+#include <BRepClass3d.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Shell.hxx>
@@ -159,7 +159,7 @@ bool StdMeshers_RadialPrism_3D::Compute(SMESH_Mesh& aMesh, const TopoDS_Shape& a
 
   // get 2 shells
   TopoDS_Solid solid = TopoDS::Solid( aShape );
-  TopoDS_Shell outerShell = BRepTools::OuterShell( solid );
+  TopoDS_Shell outerShell = BRepClass3d::OuterShell( solid );
   TopoDS_Shape innerShell;
   int nbShells = 0;
   for ( TopoDS_Iterator It (solid); It.More(); It.Next(), ++nbShells )


### PR DESCRIPTION
issue with ../../smesh-5.1.2.2/src/StdMeshers/StdMeshers_RadialPrism_3D.cpp,  had a false reference to BRepTools rather than BRepClass3d for the BRepClass3d::OuterShell method
