### PR TITLE
Improved deviation computation

### DIFF
--- a/src/wrapper/Visualization/Tesselator.cpp
+++ b/src/wrapper/Visualization/Tesselator.cpp
@@ -347,7 +347,7 @@ void Tesselator::ComputeDefaultDeviation()
     Standard_Real yDim = abs((long)aYmax - (long)aYmin);
     Standard_Real zDim = abs((long)aZmax - (long)aZmin);
 
-    Standard_Real adeviation = sqrt(xDim*xDim+yDim*yDim+zDim*zDim)/100.;
+    Standard_Real adeviation = std::max(aXmax-aXmin, std::max(aYmax-aYmin, aZmax-aZmin)) * 1e-2 ;
     myDeviation = adeviation;
 }
 


### PR DESCRIPTION
The tesselator class, basis for all mesh exporters (especially X3D) was not able to compute mesh for small geometries because of a too high deviation. This branch is able to mesh any geometry.
